### PR TITLE
Adding enabledSslProtocols setting

### DIFF
--- a/Source/NLog.Mongo/MongoTarget.cs
+++ b/Source/NLog.Mongo/MongoTarget.cs
@@ -92,8 +92,11 @@ namespace NLog.Mongo
         /// Gets or sets the Ssl Protocol versions supported by the MongoDb connection.
         /// </summary>
         /// <value>
-        /// Any Combination of Tls12, Tls11, Tls, Ssl3, and Ssl2 separated by commas.
-        /// Example: EnabledSslProtocols="Tls12,Tls11,Tls" will support TLS 1.2, 1.1, and 1.0
+        /// Any Combination of Tls12, Tls11, Tls, Ssl3, and Ssl2 separated by commas.  
+        /// This must match the name in the SslProtocols enumeration:
+        /// https://msdn.microsoft.com/en-us/library/system.security.authentication.sslprotocols(v=vs.110).aspx
+        /// In .NET 4.0 and earlier, Tls12 and Tls11 are not available.
+        /// Example: enabledSslProtocols="Tls12,Tls11,Tls" will support TLS 1.2, 1.1, and 1.0
         /// </value>
         public string EnabledSslProtocols { get; set; }
 

--- a/Source/NLog.Mongo/MongoTarget.cs
+++ b/Source/NLog.Mongo/MongoTarget.cs
@@ -6,9 +6,8 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text;
+using System.Security.Authentication;
 using System.Threading;
-using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.Builders;
@@ -88,6 +87,15 @@ namespace NLog.Mongo
         /// The name of the collection.
         /// </value>
         public string CollectionName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Ssl Protocol versions supported by the MongoDb connection.
+        /// </summary>
+        /// <value>
+        /// Any Combination of Tls12, Tls11, Tls, Ssl3, and Ssl2 separated by commas.
+        /// Example: EnabledSslProtocols="Tls12,Tls11,Tls" will support TLS 1.2, 1.1, and 1.0
+        /// </value>
+        public string EnabledSslProtocols { get; set; }
 
         /// <summary>
         /// Gets or sets the size in bytes of the capped collection.
@@ -317,19 +325,52 @@ namespace NLog.Mongo
             return new BsonString(value);
         }
 
+        private void SetEnabledSslProtocols(MongoClientSettings mongoClientSettings)
+        {
+            if (!string.IsNullOrEmpty(EnabledSslProtocols))
+            {
+                SslProtocols enabledSslProtocols = SslProtocols.None;
+                string [] sslProtocols = EnabledSslProtocols.Split(',');
+
+                foreach (string sslProtocol in sslProtocols)
+                {
+                    SslProtocols temp;
+                    if (!Enum.TryParse(sslProtocol, false, out temp))
+                    {
+                        throw new NLogConfigurationException(
+                            string.Format("TLS version {0} is not supported by this version of the .NET Framework",
+                                sslProtocol));
+                    }
+                    enabledSslProtocols = enabledSslProtocols | temp;
+                }
+
+                if (enabledSslProtocols != SslProtocols.None)
+                {
+                    mongoClientSettings.SslSettings = new SslSettings
+                    {
+                        EnabledSslProtocols = enabledSslProtocols
+                    };
+                }
+            }
+        }
+
         private MongoCollection GetCollection()
         {
             // cache mongo collection based on target name.
-            string key = string.Format("k|{0}|{1}|{2}", 
+            string key = string.Format("k|{0}|{1}|{2}|{3}", 
                 ConnectionName ?? string.Empty, 
                 ConnectionString ?? string.Empty, 
-                CollectionName ?? string.Empty);
+                CollectionName ?? string.Empty,
+                EnabledSslProtocols ?? string.Empty);
 
             return _collectionCache.GetOrAdd(key, k =>
             {
                 // create collection
                 var mongoUrl = new MongoUrl(ConnectionString);
-                var client = new MongoClient(mongoUrl);
+                var mongoClientSettings = MongoClientSettings.FromUrl(mongoUrl);
+                SetEnabledSslProtocols(mongoClientSettings);
+                var client = new MongoClient(mongoClientSettings);
+                
                 var server = client.GetServer();
                 var database = server.GetDatabase(mongoUrl.DatabaseName ?? "NLog");
 


### PR DESCRIPTION
Adding enabledSslProtocols setting for use with old driver to allow using TLS 1.2 (or other protocols) with NLog.Mongo